### PR TITLE
Update pypi classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,11 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ),
 )


### PR DESCRIPTION
For better accuracy and searchability (I guess) in PyPI.

Removed `Python :: 2.6` as it is not part of the travis build and added Python 3 classifiers - as that's the general direction we're interested in supporting this package in.
