### PR TITLE
Fix oauth_flow

### DIFF
--- a/salesforce_oauth_request/utils.py
+++ b/salesforce_oauth_request/utils.py
@@ -169,7 +169,10 @@ def oauth_flow(s, oauth_url, username=None, password=None, sandbox=False):
     assert m is not None, ("Couldn't find location.href expression in page {} "
                            "(Username or password is wrong)").format(r2.url)
 
-    u3 = m.group(1)
+    if sandbox:
+        u3 = m.group(1)
+    else:
+        u3 = "https://" + urllib.parse.urlparse(r2.url).hostname + m.group(1)
     r3 = s.get(u3)
 
     m = re.search("window.location.href\s*=['\"](.[^'\"]+)['\"]", r3.text)


### PR DESCRIPTION
I had trouble using this due to a few issues:
- The six module import only imported the urlparse function, leaving parse_qs and other functions missing
- The response from https://test.salesforce.com/services/oauth2/authorize now returns double quotes but the response from the redirect returns single quotes, so look for either.
- The r2.url value was returning https://c.[instance].content.force.com rather than the https://[instance].salesforce.com/setup/secur/RemoteAccessAuthorizationPage.apexp URL that the next request should go to.
